### PR TITLE
Added support for multiple meta queries

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -43,11 +43,11 @@ function rest_api_filter_add_filter_param( $args, $request ) {
 
 	function allow_meta_query( $valid_vars )
 	{
-	    $valid_vars = array_merge( $valid_vars, array( 'meta_key', 'meta_value', 'meta_compare' ) );
+	    $valid_vars = array_merge( $valid_vars, array( 'meta_query', 'meta_key', 'meta_value', 'meta_compare' ) );
 	    return $valid_vars;
 	}
 	$vars = allow_meta_query( $vars );
-
+	
 	foreach ( $vars as $var ) {
 		if ( isset( $filter[ $var ] ) ) {
 			$args[ $var ] = $filter[ $var ];


### PR DESCRIPTION
Added meta_query to the accepted vars so now you can make multiple meta queries at once.

samples:
(1) mydomain.com/wp-json/wp/v2/custmpost?filter[meta_key]=key&filter[meta_value]=value

(2) mydomain.com/wp-json/wp/v2/custmpost?filter[meta_query][0][key]=key1&filter[meta_query][0][value]=value1&filter[meta_query][0][key]=key2&filter[meta_query][0][value]=value2